### PR TITLE
Adding atleast_1d around numpy.imag call for complex derivatives. Acc…

### DIFF
--- a/multiPointSparse.py
+++ b/multiPointSparse.py
@@ -849,7 +849,7 @@ class multiPointSparse(object):
                     n = self.outputSize[oKey] 
                     for dvSet in self.outputWRT[oKey]:
                         if dvSet in funcSens[iKey]:
-                            deriv = (numpy.imag(con[oKey])/1e-40).reshape((n, 1))
+                            deriv = (numpy.imag(numpy.atleast_1d(con[oKey]))/1e-40).reshape((n, 1))
                             gcon[oKey][dvSet] += numpy.dot(
                                 deriv, numpy.atleast_2d(funcSens[iKey][dvSet]))
 
@@ -865,7 +865,7 @@ class multiPointSparse(object):
 
                         for dvSet in self.outputWRT[oKey]:
                             if dvSet in funcSens[iKey]:
-                                deriv = (numpy.imag(con[oKey])/1e-40).reshape((n, 1))
+                                deriv = (numpy.imag(numpy.atleast_1d(con[oKey]))/1e-40).reshape((n, 1))
                                 gcon[oKey][dvSet] += \
                                     numpy.dot(deriv, numpy.atleast_2d(
                                         funcSens[iKey][dvSet][i, :]))


### PR DESCRIPTION
…ording to https://docs.scipy.org/doc/numpy/release.html the numpy.real(x) and numpy.imag(x) behavior changed in 1.13 In 1.13+ if x is scalar the output is scalar where <1.13 returned 1d-array of length 1. Furthermore, type is maintained i.e. if the input is type float the output is also type float and if input is numpy.float64 then the output is numpy.float64. This directly affects the call, numpy.float64 does have a reshape routine but native type float does not (obviously).

Thus in order to make sure the user can provide either native or numpy float type I suggest we cast scalar inputs to 1d arrays i.e. wrap the value with atleast_1d(x). This ensures that reshape is always available.

This is demonstrated below

```
import numpy
# This fails with native python float
a = 3.14

type(numpy.imag(a))          # Returns a float
numpy.imag(a).reshape((1,1)) # This fails since float does not have reshape routine

# This works with numpy float type
b = numpy.float_(3.14)
type(numpy.imag(b))          # Returns a numpy float
numpy.imag(b).reshape((1,1)) # Works since numpy.float64 has reshape routine


# Proposed fix 
aa = 3.14
type(numpy.imag(numpy.atleast_1d(aa)))            # Returns a numpy.float64
aa_im = numpy.imag(numpy.atleast_1d(aa)).reshape((1,1))   # This works now

bb = numpy.float_(3.14)
type(numpy.imag(numpy.atleast_1d(bb)))            # Returns a numpy.float64
bb_im = numpy.imag(numpy.atleast_1d(aa)).reshape((1,1))   # Works since numpy.float64 has reshape routine

numpy.allclose(aa_im,bb_im)



# OUTPUT FROM NUMPY < 1.13

>>> import numpy
>>> 
>>> # This fails with native python float
... a = 3.14
>>> type(numpy.imag(a))          # Returns a float
<type 'numpy.ndarray'>
>>> numpy.imag(a).reshape((1,1)) # This fails since float does not have reshape routine
array([[ 0.]])
>>> 
>>> # This works with numpy float type
... b = numpy.float_(3.14)
>>> type(numpy.imag(b))          # Returns a numpy float
<type 'numpy.ndarray'>
>>> numpy.imag(b).reshape((1,1)) # Works since numpy.float64 has reshape routine
array([[ 0.]])
>>> 
>>> 
>>> # Proposed fix 
... aa = 3.14
>>> type(numpy.imag(numpy.atleast_1d(aa)))            # Returns a numpy.float64
<type 'numpy.ndarray'>
>>> aa_im = numpy.imag(numpy.atleast_1d(aa)).reshape((1,1))   # This works now
>>> 
>>> bb = numpy.float_(3.14)
>>> type(numpy.imag(numpy.atleast_1d(bb)))            # Returns a numpy.float64
<type 'numpy.ndarray'>
>>> bb_im = numpy.imag(numpy.atleast_1d(aa)).reshape((1,1))   # Works since numpy.float64 has reshape routine
>>> 
>>> numpy.allclose(aa_im,bb_im)



# OUTPUT FROM NUMPY > 1.13

>>> import numpy
>>> 
>>> # This fails with native python float
... a = 3.14
>>> type(numpy.imag(a))          # Returns a float
<type 'float'>
>>> numpy.imag(a).reshape((1,1)) # This fails since float does not have reshape routine
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'float' object has no attribute 'reshape'
>>> 
>>> # This works with numpy float type
... b = numpy.float_(3.14)
>>> type(numpy.imag(b))          # Returns a numpy float
<type 'numpy.float64'>
>>> numpy.imag(b).reshape((1,1)) # Works since numpy.float64 has reshape routine
array([[0.]])
>>> 
>>> # Proposed fix 
... aa = 3.14
>>> type(numpy.imag(numpy.atleast_1d(aa)))            # Returns a numpy.float64
<type 'numpy.ndarray'>
>>> aa_im = numpy.imag(numpy.atleast_1d(aa)).reshape((1,1))   # This works now
>>> 
>>> bb = numpy.float_(3.14)
>>> type(numpy.imag(numpy.atleast_1d(bb)))            # Returns a numpy.float64
<type 'numpy.ndarray'>
>>> bb_im = numpy.imag(numpy.atleast_1d(aa)).reshape((1,1))   # Works since numpy.float64 has reshape routine
>>> 
>>> numpy.allclose(aa_im,bb_im)
True
```