### PR TITLE
fixed pyOptSparse dependency

### DIFF
--- a/multipoint/__init__.py
+++ b/multipoint/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 
 from .multiPointSparse import multiPointSparse

--- a/multipoint/multiPointSparse.py
+++ b/multipoint/multiPointSparse.py
@@ -455,9 +455,7 @@ class multiPointSparse(object):
         optProb : pyOptSparse optimization problem class
             The optProb object to use
         """
-
-        optProb.finalizeDesignVariables()
-        optProb.finalizeConstraints()
+        optProb.finalize()
 
         # Since there is no distinction between objective(s) and
         # constraints just put everything in conKeys, including the

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,11 @@ setup(
     packages=[
         "multipoint",
     ],
-    install_requires=["numpy>=1.16", "mpi4py>=3.0", "mdolab-baseclasses>=1.2.4"],
+    install_requires=[
+        "numpy>=1.16",
+        "mpi4py>=3.0",
+        "mdolab-baseclasses>=1.2.4",
+        "pyoptsparse>2.5.0"
+    ],
     classifiers=["Operating System :: OS Independent", "Programming Language :: Python"],
 )


### PR DESCRIPTION
## Purpose
We implicitly depend on pyOptSparse, and a recent change there (mdolab/pyoptsparse#221) broke multipoint. This PR does the following
- update API to match the changes in pyOptSparse
- explicitly depend on pyOptSparse, with a pinned version matching when this change happened over there

Note that this depends on a version of pyOptSparse that does not exist yet, but mdolab/pyoptsparse#219 will bump the version.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Existing tests will still fail because Docker is not updated. We have no choice but to merge this in, and wait for build bot to give the all clear the next day.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
