### PR TITLE
Moved pyoptsparse dependency to testing

### DIFF
--- a/.github/build_real.sh
+++ b/.github/build_real.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-pip install .
+pip install .[testing]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,9 @@ setup(
         "numpy>=1.16",
         "mpi4py>=3.0",
         "mdolab-baseclasses>=1.2.4",
-        "pyoptsparse>2.5.0"
     ],
+    extras_require={
+        "testing": ["pyoptsparse>=2.5.1"],
+    },
     classifiers=["Operating System :: OS Independent", "Programming Language :: Python"],
 )


### PR DESCRIPTION
## Purpose
After some thought, we decided it's probably best not to specify pyoptsparse as a core dependency, since the core functionality (constructing different procsets) does not rely on it. I have moved it to `testing` and updated the build script accordingly.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Tests will probably still fail.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
